### PR TITLE
Papers-on-a-desk web GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Master your tasks - KanBan-style RESTful API for managing tasks as cards
 - Data model with Boards, Lists, Cards, and Categories
 - API with some CRUD endpoints but some obvious missing
 - TUI to show board of lists
+- Web GUI showing lists as "papers on a desk"
 
 Currently an alpha quality software, missing key features, see #93.
 
@@ -19,9 +20,35 @@ Run it
 
 - `git clone https://github.com/ctengel/taskmaster.git`
 - `fastapi dev --port 29325 kanapi.py`
+- Open http://127.0.0.1:29325/desk/ for the "papers on a desk" web GUI
 - `KANAPI_URL=http://127.0.0.1:29325/ ./kantui.py`
 - `KANAPI_URL=http://127.0.0.1:29325/ ./kancli.py --help`
 - `KANAPI_URL=http://127.0.0.1:29325/ flask --app tmgui run --port 29319`
+
+### Desk web GUI
+
+The desk (`desk/`, served by kanapi at `/desk/`) shows each list as a paper
+laid side by side on a desk.  Papers can be created on the fly, dragged into a
+new order, renamed, and "put away" into a drawer, optionally with a wakeup
+date so they come back to the desk automatically.  A list's `board_order`
+holds its place in the row; a null `board_order` means it is put away, like a
+closed card's null `list_order`.
+
+- Everything works by mouse (drag & drop papers and tasks) or keyboard: the
+  TUI keys (`n`/`e`/`m`/`wasd`/`c`) plus `N` new paper, `A`/`D` move paper,
+  `r` rename, `z` put away, `b` drawer, `p`/`P` print, `g` refresh.
+- The search box (`/`) is an *upsert*: type to find a task on visible (or
+  all) papers, and if it isn't found, Enter writes it on the current paper.
+- Print one paper (its printer button), marked papers (checkboxes), or the
+  whole desk via the browser's print dialog.
+
+Notes:
+- Lists that existed before the desk have no `board_order`, so they start in
+  the drawer; pull out the ones you want on the desk once.
+- Closing a task needs one list created with `--closed` (see below).
+- Task colors come from `category_color` (e.g.
+  `curl -X POST localhost:29325/categories/ -H 'Content-Type: application/json' -d '{"category_id": 1, "category_name": "Home", "category_color": "#4C8A64"}'`);
+  categories without a color get a stable fallback color.
 
 ### Recommended setup
 
@@ -75,7 +102,8 @@ Roadmap
 -------
 
 - packaging
-- server side board definition
+- ~~server side board definition~~ done: desk order/away state lives in `board_order`
+- desk paradigm in TUI and Android clients
 
 History
 -------

--- a/desk/api.js
+++ b/desk/api.js
@@ -1,0 +1,25 @@
+/* Thin fetch wrapper over the TaskMaster KanBan API (same origin). */
+
+async function api(method, path, body) {
+    const opts = { method };
+    if (body !== undefined) {
+        opts.headers = { 'Content-Type': 'application/json' };
+        opts.body = JSON.stringify(body);
+    }
+    const res = await fetch(path, opts);
+    if (!res.ok) {
+        throw new Error(`${method} ${path} failed (${res.status})`);
+    }
+    return res.json();
+}
+
+export const getCategories = () => api('GET', '/categories/');
+export const getLists = (away) => api('GET', away === undefined ? '/lists/' : `/lists/?away=${away}`);
+export const getList = (listId) => api('GET', `/lists/${listId}`);
+export const createList = (data) => api('POST', '/lists/', data);
+export const patchList = (listId, data) => api('PATCH', `/lists/${listId}`, data);
+export const createCard = (listId, data) => api('POST', `/lists/${listId}/cards/`, data);
+export const patchCard = (cardId, data) => api('PATCH', `/cards/${cardId}`, data);
+export const moveCard = (cardId, data) => api('POST', `/cards/${cardId}/move`, data);
+export const closeCard = (cardId) => api('POST', `/cards/${cardId}/close`, {});
+export const rebalance = (listId) => api('POST', `/lists/${listId}/rebalance`, {});

--- a/desk/app.js
+++ b/desk/app.js
@@ -1,0 +1,912 @@
+/* TaskMaster Desk — papers on a desk.
+   Paper = List. board_order = position in the row; null board_order = put away.
+   Mouse: pointer-event dragging. Keyboard: mirrors kantui (n/e/m/wasd/c) plus paper keys. */
+
+import * as api from './api.js';
+
+const ORDER_MIN = 1;              // mirror kanapi.py MIN_ORDER / MAX_ORDER
+const ORDER_MAX = 2147483646;
+const DEFAULT_CATEGORY = 1;       // same default as kantui
+const DRAG_THRESHOLD = 5;         // px before a press becomes a drag
+// fallback per-category colors when category_color is unset in the DB
+const FALLBACK_COLORS = ['#4C8A64', '#5E7FB0', '#C08A3E', '#A05A6E', '#7A6AA8', '#688391'];
+
+const state = {
+    categories: new Map(),     // category_id -> Category
+    papers: new Map(),         // list_id -> ListWithCards (on desk)
+    drawer: [],                // away List rows (no cards)
+    drawerCards: new Map(),    // list_id -> ListWithCards, lazily fetched for upsert "all"
+    focus: { listId: null, cardId: null },
+    picked: null,              // card_id picked up for keyboard moves
+    printSelection: new Set(), // list_ids marked for printing
+    lastCategory: DEFAULT_CATEGORY,
+    drawerOpen: false,
+};
+
+const upsert = { query: '', scope: 'visible', results: [], sel: 0 };
+
+const deskEl = document.getElementById('desk');
+const drawerEl = document.getElementById('drawer');
+const drawerTabsEl = document.getElementById('drawer-tabs');
+const drawerEmptyEl = document.getElementById('drawer-empty');
+const upsertInput = document.getElementById('upsert-input');
+const upsertScopeBtn = document.getElementById('upsert-scope');
+const upsertResultsEl = document.getElementById('upsert-results');
+const awayDialog = document.getElementById('away-dialog');
+const awayNameEl = document.getElementById('away-name');
+const awayDateEl = document.getElementById('away-date');
+
+let lastLoad = 0;
+let awayTarget = null;
+
+/* ---------- helpers ---------- */
+
+async function guard(fn) {
+    try {
+        await fn();
+    } catch (err) {
+        console.error(err);
+        alert(err.message);
+        try { await reload(); } catch { /* server gone; alert already shown */ }
+    }
+}
+
+function paperSortKey(list) {
+    // null board_order (woken sleeper) sorts last, like the server
+    return list.board_order === null ? ORDER_MAX + 1 : list.board_order;
+}
+
+function deskPapers() {
+    return [...state.papers.values()].sort(
+        (a, b) => paperSortKey(a) - paperSortKey(b) || a.list_id - b.list_id);
+}
+
+function currentPaper() {
+    return state.papers.get(state.focus.listId) || deskPapers()[0] || null;
+}
+
+function categoryColor(categoryId) {
+    const cat = state.categories.get(categoryId);
+    return (cat && cat.category_color)
+        || FALLBACK_COLORS[categoryId % FALLBACK_COLORS.length];
+}
+
+function isWoken(list) {
+    return list.board_order === null && list.list_wakeup;
+}
+
+function upsertQuery() {
+    return upsert.query.trim().toLowerCase();
+}
+
+/* ---------- data loading ---------- */
+
+async function reload() {
+    const [cats, onDesk, away] = await Promise.all(
+        [api.getCategories(), api.getLists(false), api.getLists(true)]);
+    state.categories = new Map(cats.map((c) => [c.category_id, c]));
+    const full = await Promise.all(onDesk.map((l) => api.getList(l.list_id)));
+    state.papers = new Map(full.map((l) => [l.list_id, l]));
+    state.drawer = away;
+    state.drawerCards.clear();
+    for (const id of state.printSelection) {
+        if (!state.papers.has(id)) state.printSelection.delete(id);
+    }
+    if (!state.papers.size && state.drawer.length) state.drawerOpen = true;
+    lastLoad = Date.now();
+    render();
+}
+
+async function refreshPapers(listIds) {
+    const ids = [...new Set(listIds)].filter((id) => state.papers.has(id));
+    const full = await Promise.all(ids.map((id) => api.getList(id)));
+    for (const l of full) state.papers.set(l.list_id, l);
+}
+
+/* If a move left two adjacent cards with (nearly) no gap, re-space the list */
+async function checkRebalance(listId) {
+    const list = state.papers.get(listId);
+    if (!list) return;
+    const orders = list.cards.map((c) => c.list_order || 0);
+    for (let i = 1; i < orders.length; i++) {
+        if (orders[i] - orders[i - 1] <= 1) {
+            await api.rebalance(listId);
+            await refreshPapers([listId]);
+            return;
+        }
+    }
+}
+
+async function doMoveCard(cardId, payload, listIds) {
+    await api.moveCard(cardId, payload);
+    await refreshPapers(listIds);
+    for (const id of new Set(listIds)) await checkRebalance(id);
+    render();
+}
+
+/* ---------- paper ordering ---------- */
+
+function orderAtEnd() {
+    const orders = deskPapers().map((p) => p.board_order).filter((o) => o !== null);
+    if (!orders.length) return Math.floor((ORDER_MIN + ORDER_MAX) / 2);
+    return Math.floor((Math.max(...orders) + ORDER_MAX) / 2);
+}
+
+/* Persist a paper's position given the full desired row of list_ids */
+async function placePaperAt(listId, rowIds) {
+    const idx = rowIds.indexOf(listId);
+    const orderOf = (id) => {
+        const p = state.papers.get(id);
+        return p ? p.board_order : null;
+    };
+    let prev = null;
+    for (let i = idx - 1; i >= 0; i--) {
+        if (orderOf(rowIds[i]) !== null) { prev = orderOf(rowIds[i]); break; }
+    }
+    let next = null;
+    for (let i = idx + 1; i < rowIds.length; i++) {
+        if (orderOf(rowIds[i]) !== null) { next = orderOf(rowIds[i]); break; }
+    }
+    const lo = prev === null ? ORDER_MIN : prev;
+    const hi = next === null ? ORDER_MAX : next;
+    if (hi - lo <= 1) {
+        // gap exhausted: renumber the whole row (papers are few)
+        const step = Math.floor((ORDER_MAX - ORDER_MIN) / (rowIds.length + 1));
+        for (let i = 0; i < rowIds.length; i++) {
+            const order = ORDER_MIN + (i + 1) * step;
+            const updated = await api.patchList(rowIds[i], { board_order: order });
+            if (state.papers.has(rowIds[i])) state.papers.set(rowIds[i], { ...state.papers.get(rowIds[i]), ...updated });
+        }
+    } else {
+        const updated = await api.patchList(listId, { board_order: Math.floor((lo + hi) / 2) });
+        state.papers.set(listId, { ...state.papers.get(listId), ...updated });
+    }
+    render();
+}
+
+/* ---------- rendering ---------- */
+
+function render() {
+    deskEl.textContent = '';
+    const q = upsertQuery();
+    for (const list of deskPapers()) deskEl.append(paperEl(list, q));
+    renderDrawer();
+    restoreFocus();
+}
+
+function restoreFocus() {
+    const active = document.activeElement;
+    if (active && active !== document.body && !deskEl.contains(active)) return;
+    const { listId, cardId } = state.focus;
+    let el = null;
+    if (cardId !== null) el = deskEl.querySelector(`.card[data-card-id="${cardId}"]`);
+    if (!el && listId !== null) el = deskEl.querySelector(`.paper[data-list-id="${listId}"] h2`);
+    if (el) {
+        el.focus({ preventScroll: true });
+        el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
+}
+
+function paperEl(list, q) {
+    const el = document.createElement('article');
+    el.className = 'paper';
+    el.dataset.listId = list.list_id;
+    el.style.setProperty('--tilt', `${(((list.list_id * 7) % 5) - 2) * 0.4}deg`);
+
+    const header = document.createElement('header');
+    const h2 = document.createElement('h2');
+    h2.textContent = list.list_name;
+    h2.tabIndex = 0;
+    h2.addEventListener('dblclick', () => renamePaper(list));
+    header.append(h2);
+
+    const tools = document.createElement('span');
+    tools.className = 'tools';
+    const printSel = document.createElement('input');
+    printSel.type = 'checkbox';
+    printSel.title = 'Include in print';
+    printSel.checked = state.printSelection.has(list.list_id);
+    printSel.addEventListener('change', () => togglePrintSelection(list));
+    const printBtn = toolButton('\u{1F5A8}', 'Print this paper', () => {
+        state.printSelection = new Set([list.list_id]);
+        render();
+        window.print();
+    });
+    const awayBtn = toolButton('\u{1F5C4}', 'Put away (z)', () => putAwayDialog(list));
+    tools.append(printSel, printBtn, awayBtn);
+    header.append(tools);
+    el.append(header);
+
+    const ul = document.createElement('ul');
+    ul.className = 'cards';
+    let anyMatch = false;
+    for (const card of list.cards) {
+        const li = cardEl(card, list, q);
+        if (q && li.classList.contains('match')) anyMatch = true;
+        ul.append(li);
+    }
+    el.append(ul);
+
+    const blank = document.createElement('div');
+    blank.className = 'blank-lines';
+    blank.title = 'Add a task (n)';
+    blank.addEventListener('click', () => newCard(list));
+    el.append(blank);
+
+    if (q && !anyMatch) el.classList.add('dimmed');
+
+    if (isWoken(list)) {
+        el.classList.add('woken');
+        el.title = 'Woke up — click to keep on the desk';
+        el.addEventListener('pointerdown', () => guard(async () => {
+            const updated = await api.patchList(list.list_id,
+                { board_order: orderAtEnd(), list_wakeup: null });
+            state.papers.set(list.list_id, { ...state.papers.get(list.list_id), ...updated });
+            render();
+        }), { once: true });
+    }
+
+    setupPaperDrag(el, header, list);
+    return el;
+}
+
+function cardEl(card, list, q) {
+    const li = document.createElement('li');
+    li.className = 'card';
+    li.dataset.cardId = card.card_id;
+    li.tabIndex = 0;
+    li.style.setProperty('--cat-color', categoryColor(card.category_id));
+
+    const name = document.createElement('span');
+    name.className = 'name';
+    name.textContent = card.card_name;
+    name.addEventListener('dblclick', () => editCard(card, list));
+    li.append(name);
+
+    if (card.card_due) {
+        const due = document.createElement('span');
+        due.className = 'due';
+        due.textContent = card.card_due;
+        li.append(due);
+    }
+
+    const cat = document.createElement('span');
+    cat.className = 'cat'; // shown only in print
+    const category = state.categories.get(card.category_id);
+    cat.textContent = category ? category.category_name : '';
+    li.append(cat);
+
+    li.append(toolButton('✎', 'Edit (e)', () => editCard(card, list)));
+    li.append(toolButton('✓', 'Done (c)', () => doCloseCard(card, list)));
+
+    if (state.picked === card.card_id) li.classList.add('picked');
+    if (q) li.classList.add(card.card_name.toLowerCase().includes(q) ? 'match' : 'dimmed');
+
+    li.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && e.target === li) editCard(card, list);
+    });
+
+    setupCardDrag(li, card, list);
+    return li;
+}
+
+function toolButton(glyph, title, onClick) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = glyph;
+    btn.title = title;
+    btn.tabIndex = -1;
+    btn.addEventListener('click', (e) => { e.stopPropagation(); onClick(); });
+    return btn;
+}
+
+function renderDrawer() {
+    drawerEl.hidden = !state.drawerOpen;
+    drawerTabsEl.textContent = '';
+    drawerEmptyEl.hidden = state.drawer.length > 0;
+    for (const list of state.drawer) {
+        const li = document.createElement('li');
+        li.tabIndex = 0;
+        li.textContent = list.list_name;
+        if (list.list_wakeup) {
+            const wake = document.createElement('span');
+            wake.className = 'wake';
+            wake.textContent = `wakes ${list.list_wakeup}`;
+            li.append(wake);
+        }
+        const pull = () => guard(() => pullOut(list.list_id));
+        li.addEventListener('click', pull);
+        li.addEventListener('keydown', (e) => { if (e.key === 'Enter') pull(); });
+        drawerTabsEl.append(li);
+    }
+}
+
+/* ---------- paper actions ---------- */
+
+function newPaper() {
+    guard(async () => {
+        const created = await api.createList(
+            { list_name: 'Untitled', board_order: orderAtEnd() });
+        state.papers.set(created.list_id, { ...created, cards: [] });
+        state.focus = { listId: created.list_id, cardId: null };
+        render();
+        renamePaper(state.papers.get(created.list_id));
+    });
+}
+
+function renamePaper(list) {
+    const h2 = deskEl.querySelector(`.paper[data-list-id="${list.list_id}"] h2`);
+    if (!h2) return;
+    h2.textContent = '';
+    h2.append(inlineForm({
+        value: list.list_name === 'Untitled' ? '' : list.list_name,
+        onCommit: (v) => guard(async () => {
+            const updated = await api.patchList(list.list_id, { list_name: v.name });
+            state.papers.set(list.list_id, { ...state.papers.get(list.list_id), ...updated });
+            render();
+        }),
+        onCancel: render,
+    }));
+}
+
+function putAwayDialog(list) {
+    awayTarget = list;
+    awayNameEl.textContent = list.list_name;
+    awayDateEl.value = '';
+    awayDialog.showModal();
+}
+
+awayDialog.addEventListener('close', () => {
+    const list = awayTarget;
+    awayTarget = null;
+    if (awayDialog.returnValue !== 'ok' || !list) return;
+    const wakeup = awayDateEl.value || null;
+    guard(async () => {
+        await api.patchList(list.list_id, { board_order: null, list_wakeup: wakeup });
+        state.focus = { listId: null, cardId: null };
+        await reload();
+    });
+});
+
+async function pullOut(listId) {
+    await api.patchList(listId, { board_order: orderAtEnd(), list_wakeup: null });
+    await reload();
+    state.focus = { listId, cardId: null };
+    restoreFocus();
+}
+
+function movePaper(list, dir) {
+    const ids = deskPapers().map((p) => p.list_id);
+    const i = ids.indexOf(list.list_id);
+    const j = i + dir;
+    if (j < 0 || j >= ids.length) return;
+    ids.splice(i, 1);
+    ids.splice(j, 0, list.list_id);
+    state.focus.listId = list.list_id;
+    guard(() => placePaperAt(list.list_id, ids));
+}
+
+/* ---------- card actions ---------- */
+
+function newCard(list) {
+    const ul = deskEl.querySelector(`.paper[data-list-id="${list.list_id}"] .cards`);
+    if (!ul || ul.querySelector('.inline-form')) return;
+    const li = document.createElement('li');
+    li.append(inlineForm({
+        withCategory: true,
+        categoryId: state.lastCategory,
+        onCommit: (v) => guard(async () => {
+            state.lastCategory = v.categoryId;
+            const created = await api.createCard(list.list_id,
+                { card_name: v.name, category_id: v.categoryId });
+            state.focus = { listId: list.list_id, cardId: created.card_id };
+            await refreshPapers([list.list_id]);
+            render();
+            newCard(state.papers.get(list.list_id)); // rapid entry until Escape
+        }),
+        onCancel: render,
+    }));
+    ul.append(li);
+    li.querySelector('input[type="text"]').focus();
+}
+
+function editCard(card, list) {
+    const li = deskEl.querySelector(`.card[data-card-id="${card.card_id}"]`);
+    if (!li) return;
+    li.textContent = '';
+    li.append(inlineForm({
+        value: card.card_name,
+        withDate: true,
+        date: card.card_due,
+        onCommit: (v) => guard(async () => {
+            await api.patchCard(card.card_id, { card_name: v.name, card_due: v.date });
+            await refreshPapers([list.list_id]);
+            render();
+        }),
+        onCancel: render,
+    }));
+    li.querySelector('input[type="text"]').focus();
+}
+
+function doCloseCard(card, list) {
+    guard(async () => {
+        await api.closeCard(card.card_id);
+        if (state.focus.cardId === card.card_id) state.focus.cardId = null;
+        if (state.picked === card.card_id) state.picked = null;
+        // refresh the source and any on-desk "closed" paper the card landed on
+        const affected = [list.list_id,
+            ...deskPapers().filter((p) => p.list_closed).map((p) => p.list_id)];
+        await refreshPapers(affected);
+        render();
+    });
+}
+
+/* ---------- inline editing ---------- */
+
+function inlineForm({ value = '', date = null, categoryId = DEFAULT_CATEGORY,
+                      withDate = false, withCategory = false, onCommit, onCancel }) {
+    const form = document.createElement('form');
+    form.className = 'inline-form';
+    let done = false;
+
+    const name = document.createElement('input');
+    name.type = 'text';
+    name.value = value;
+    form.append(name);
+
+    let dateInput = null;
+    if (withDate) {
+        dateInput = document.createElement('input');
+        dateInput.type = 'date';
+        dateInput.value = date || '';
+        form.append(dateInput);
+    }
+
+    let catSelect = null;
+    if (withCategory) {
+        catSelect = document.createElement('select');
+        for (const cat of state.categories.values()) {
+            const opt = document.createElement('option');
+            opt.value = cat.category_id;
+            opt.textContent = cat.category_name;
+            opt.selected = cat.category_id === categoryId;
+            catSelect.append(opt);
+        }
+        form.append(catSelect);
+    }
+
+    const finish = (commit) => {
+        if (done) return;
+        done = true;
+        if (commit) {
+            onCommit({
+                name: name.value.trim(),
+                date: dateInput ? (dateInput.value || null) : undefined,
+                categoryId: catSelect ? Number(catSelect.value) : undefined,
+            });
+        } else {
+            onCancel();
+        }
+    };
+
+    form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        finish(Boolean(name.value.trim()));
+    });
+    form.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') { e.stopPropagation(); finish(false); }
+    });
+    form.addEventListener('focusout', (e) => {
+        if (!form.contains(e.relatedTarget)) finish(Boolean(name.value.trim()));
+    });
+    return form;
+}
+
+/* ---------- drag & drop (pointer events) ---------- */
+
+function setupPaperDrag(el, header, list) {
+    header.addEventListener('pointerdown', (e) => {
+        if (e.button !== 0) return;
+        if (e.target.closest('button, input, select, .inline-form')) return;
+        const startX = e.clientX;
+        const startY = e.clientY;
+        let dragging = false;
+
+        const onMove = (ev) => {
+            if (!dragging) {
+                if (Math.hypot(ev.clientX - startX, ev.clientY - startY) < DRAG_THRESHOLD) return;
+                dragging = true;
+                el.classList.add('drag');
+            }
+            const siblings = [...deskEl.querySelectorAll('.paper')].filter((p) => p !== el);
+            let before = null;
+            for (const sib of siblings) {
+                const r = sib.getBoundingClientRect();
+                if (ev.clientX < r.left + r.width / 2) { before = sib; break; }
+            }
+            if (before) deskEl.insertBefore(el, before);
+            else deskEl.append(el);
+        };
+        const onUp = () => {
+            document.removeEventListener('pointermove', onMove);
+            document.removeEventListener('pointerup', onUp);
+            document.removeEventListener('pointercancel', onUp);
+            if (!dragging) {
+                state.focus = { listId: list.list_id, cardId: null };
+                header.querySelector('h2')?.focus();
+                return;
+            }
+            el.classList.remove('drag');
+            const rowIds = [...deskEl.querySelectorAll('.paper')]
+                .map((p) => Number(p.dataset.listId));
+            state.focus = { listId: list.list_id, cardId: null };
+            guard(() => placePaperAt(list.list_id, rowIds));
+        };
+        document.addEventListener('pointermove', onMove);
+        document.addEventListener('pointerup', onUp);
+        document.addEventListener('pointercancel', onUp);
+    });
+}
+
+function setupCardDrag(li, card, list) {
+    li.addEventListener('pointerdown', (e) => {
+        if (e.button !== 0) return;
+        if (e.target.closest('button, input, select, .inline-form')) return;
+        const startX = e.clientX;
+        const startY = e.clientY;
+        const originListId = list.list_id;
+        const originPrev = li.previousElementSibling;
+        let dragging = false;
+        let clone = null;
+
+        const onMove = (ev) => {
+            if (!dragging) {
+                if (Math.hypot(ev.clientX - startX, ev.clientY - startY) < DRAG_THRESHOLD) return;
+                dragging = true;
+                clone = li.cloneNode(true);
+                clone.id = 'drag-clone';
+                document.body.append(clone);
+                li.classList.add('drop-slot');
+            }
+            clone.style.left = `${ev.clientX + 8}px`;
+            clone.style.top = `${ev.clientY - 12}px`;
+            const under = document.elementFromPoint(ev.clientX, ev.clientY);
+            const paper = under && under.closest('.paper');
+            if (!paper) return;
+            const ul = paper.querySelector('.cards');
+            let before = null;
+            for (const sib of ul.children) {
+                if (sib === li || !sib.classList.contains('card')) continue;
+                const r = sib.getBoundingClientRect();
+                if (ev.clientY < r.top + r.height / 2) { before = sib; break; }
+            }
+            if (before) ul.insertBefore(li, before);
+            else ul.append(li);
+        };
+        const onUp = () => {
+            document.removeEventListener('pointermove', onMove);
+            document.removeEventListener('pointerup', onUp);
+            document.removeEventListener('pointercancel', onUp);
+            if (!dragging) {
+                li.focus();
+                return;
+            }
+            clone.remove();
+            li.classList.remove('drop-slot');
+            const destPaper = li.closest('.paper');
+            const destListId = Number(destPaper.dataset.listId);
+            if (destListId === originListId && li.previousElementSibling === originPrev) {
+                li.focus();
+                return; // dropped back where it started
+            }
+            const prev = li.previousElementSibling;
+            const next = li.nextElementSibling;
+            const payload = { list_id: destListId };
+            if (prev && prev.classList.contains('card')) {
+                payload.after_card = Number(prev.dataset.cardId);
+            } else if (next && next.classList.contains('card')) {
+                payload.before_card = Number(next.dataset.cardId);
+            }
+            state.focus = { listId: destListId, cardId: card.card_id };
+            guard(() => doMoveCard(card.card_id, payload, [originListId, destListId]));
+        };
+        document.addEventListener('pointermove', onMove);
+        document.addEventListener('pointerup', onUp);
+        document.addEventListener('pointercancel', onUp);
+    });
+}
+
+/* ---------- keyboard ---------- */
+
+function navigate(key) {
+    if (state.picked !== null) { movePicked(key); return; }
+    const papers = deskPapers();
+    if (!papers.length) return;
+    const list = currentPaper();
+    const cards = list.cards;
+    const idx = cards.findIndex((c) => c.card_id === state.focus.cardId);
+    if (key === 's') {
+        if (idx < cards.length - 1) {
+            state.focus = { listId: list.list_id, cardId: cards[idx + 1].card_id };
+        }
+    } else if (key === 'w') {
+        if (idx > 0) {
+            state.focus = { listId: list.list_id, cardId: cards[idx - 1].card_id };
+        } else {
+            state.focus = { listId: list.list_id, cardId: null }; // up to the header
+        }
+    } else {
+        const pi = papers.indexOf(list);
+        const target = papers[pi + (key === 'd' ? 1 : -1)];
+        if (!target) return;
+        state.focus = {
+            listId: target.list_id,
+            cardId: target.cards.length ? target.cards[0].card_id : null,
+        };
+    }
+    restoreFocus();
+}
+
+function movePicked(key) {
+    const list = state.papers.get(state.focus.listId);
+    if (!list) return;
+    const cards = list.cards;
+    const idx = cards.findIndex((c) => c.card_id === state.picked);
+    if (idx < 0) return;
+    let payload = null;
+    let affected = [list.list_id];
+    if (key === 'w' && idx > 0) {
+        payload = { list_id: list.list_id, before_card: cards[idx - 1].card_id };
+    } else if (key === 's' && idx < cards.length - 1) {
+        payload = { list_id: list.list_id, after_card: cards[idx + 1].card_id };
+    } else if (key === 'a' || key === 'd') {
+        const papers = deskPapers();
+        const target = papers[papers.indexOf(list) + (key === 'd' ? 1 : -1)];
+        if (!target) return;
+        payload = { list_id: target.list_id };
+        affected = [list.list_id, target.list_id];
+        state.focus.listId = target.list_id;
+    }
+    if (!payload) return;
+    state.focus.cardId = state.picked;
+    guard(() => doMoveCard(state.picked, payload, affected));
+}
+
+function pickDrop() {
+    if (state.picked !== null) {
+        state.picked = null;
+    } else if (state.focus.cardId !== null) {
+        state.picked = state.focus.cardId;
+    }
+    render();
+}
+
+function togglePrintSelection(list) {
+    if (state.printSelection.has(list.list_id)) state.printSelection.delete(list.list_id);
+    else state.printSelection.add(list.list_id);
+    render();
+}
+
+function toggleDrawer() {
+    state.drawerOpen = !state.drawerOpen;
+    renderDrawer();
+}
+
+document.addEventListener('keydown', (e) => {
+    if (e.ctrlKey || e.metaKey || e.altKey || e.defaultPrevented) return;
+    if (e.target.closest('input, textarea, select')) return;
+    if (awayDialog.open) return;
+    const list = currentPaper();
+    const card = list && list.cards.find((c) => c.card_id === state.focus.cardId);
+    switch (e.key) {
+        case 'w': case 's': case 'a': case 'd': navigate(e.key); break;
+        case 'n': if (list) newCard(list); break;
+        case 'e': case 'Enter':
+            if (card) editCard(card, list);
+            else if (e.key === 'Enter' && list && e.target.tagName === 'H2') renamePaper(list);
+            else return;
+            break;
+        case 'm': pickDrop(); break;
+        case 'c': if (card) doCloseCard(card, list); break;
+        case 'N': newPaper(); break;
+        case 'A': if (list) movePaper(list, -1); break;
+        case 'D': if (list) movePaper(list, 1); break;
+        case 'r': if (list) renamePaper(list); break;
+        case 'z': if (list) putAwayDialog(list); break;
+        case 'b': toggleDrawer(); break;
+        case '/': case 'u': upsertInput.focus(); upsertInput.select(); break;
+        case 'p': if (list) togglePrintSelection(list); break;
+        case 'P': window.print(); break;
+        case 'g': guard(reload); break;
+        case 'Escape':
+            if (state.picked !== null) { state.picked = null; render(); }
+            else if (upsert.query) clearUpsert();
+            else if (state.drawerOpen) toggleDrawer();
+            break;
+        default: return;
+    }
+    e.preventDefault();
+});
+
+document.addEventListener('focusin', (e) => {
+    const cardLi = e.target.closest('.card');
+    const paper = e.target.closest('.paper');
+    if (cardLi) {
+        state.focus = {
+            listId: Number(paper.dataset.listId),
+            cardId: Number(cardLi.dataset.cardId),
+        };
+    } else if (paper) {
+        state.focus = { listId: Number(paper.dataset.listId), cardId: null };
+    }
+});
+
+/* ---------- upsert: search that becomes creation ---------- */
+
+function upsertMatches() {
+    const q = upsertQuery();
+    const out = [];
+    if (!q) return out;
+    for (const l of deskPapers()) {
+        for (const c of l.cards) {
+            if (c.card_name.toLowerCase().includes(q)) out.push({ card: c, list: l, away: false });
+        }
+    }
+    if (upsert.scope === 'all') {
+        for (const l of state.drawerCards.values()) {
+            for (const c of l.cards) {
+                if (c.card_name.toLowerCase().includes(q)) out.push({ card: c, list: l, away: true });
+            }
+        }
+    }
+    return out.slice(0, 12);
+}
+
+function upsertTarget() {
+    return currentPaper();
+}
+
+function renderUpsert() {
+    const q = upsert.query.trim();
+    upsertResultsEl.textContent = '';
+    upsertResultsEl.hidden = !q;
+    render(); // applies match/dim highlighting from the current query
+    if (!q) return;
+    upsert.results = upsertMatches();
+    upsert.sel = Math.min(upsert.sel, upsert.results.length);
+    upsert.results.forEach((r, i) => {
+        const li = document.createElement('li');
+        if (i === upsert.sel) li.classList.add('selected');
+        const name = document.createElement('span');
+        name.textContent = r.card.card_name;
+        const where = document.createElement('span');
+        where.className = 'where';
+        where.textContent = r.list.list_name + (r.away ? ' (drawer)' : '');
+        li.append(name, where);
+        li.addEventListener('click', () => activateResult(r));
+        upsertResultsEl.append(li);
+    });
+    const target = upsertTarget();
+    const create = document.createElement('li');
+    create.className = 'create';
+    if (upsert.sel === upsert.results.length) create.classList.add('selected');
+    create.textContent = target
+        ? `✚ Add “${q}” to ${target.list_name}`
+        : 'No papers on the desk — create one first (N)';
+    if (target) create.addEventListener('click', createFromUpsert);
+    upsertResultsEl.append(create);
+}
+
+function activateResult(r) {
+    if (r.away) {
+        guard(async () => {
+            await pullOut(r.list.list_id);
+            clearUpsert();
+            state.focus = { listId: r.list.list_id, cardId: r.card.card_id };
+            restoreFocus();
+        });
+    } else {
+        clearUpsert();
+        state.focus = { listId: r.list.list_id, cardId: r.card.card_id };
+        restoreFocus();
+    }
+}
+
+function createFromUpsert() {
+    const target = upsertTarget();
+    const cardName = upsert.query.trim();
+    if (!target || !cardName) return;
+    guard(async () => {
+        const created = await api.createCard(target.list_id,
+            { card_name: cardName, category_id: state.lastCategory });
+        state.focus = { listId: target.list_id, cardId: created.card_id };
+        await refreshPapers([target.list_id]);
+        clearUpsert();
+        restoreFocus();
+    });
+}
+
+function clearUpsert() {
+    upsertInput.value = '';
+    upsert.query = '';
+    upsert.results = [];
+    upsert.sel = 0;
+    upsertResultsEl.hidden = true;
+    upsertInput.blur();
+    render();
+}
+
+upsertInput.addEventListener('input', () => {
+    upsert.query = upsertInput.value;
+    upsert.sel = 0;
+    renderUpsert();
+});
+
+upsertInput.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowDown') {
+        upsert.sel = Math.min(upsert.sel + 1, upsert.results.length);
+    } else if (e.key === 'ArrowUp') {
+        upsert.sel = Math.max(upsert.sel - 1, 0);
+    } else if (e.key === 'Enter') {
+        if (upsert.sel < upsert.results.length) activateResult(upsert.results[upsert.sel]);
+        else createFromUpsert();
+        return;
+    } else if (e.key === 'Escape') {
+        clearUpsert();
+        return;
+    } else {
+        return;
+    }
+    e.preventDefault();
+    renderUpsert();
+});
+
+upsertScopeBtn.addEventListener('click', () => {
+    guard(async () => {
+        if (upsert.scope === 'visible') {
+            upsert.scope = 'all';
+            const full = await Promise.all(state.drawer.map((l) => api.getList(l.list_id)));
+            state.drawerCards = new Map(full.map((l) => [l.list_id, l]));
+        } else {
+            upsert.scope = 'visible';
+        }
+        upsertScopeBtn.textContent = upsert.scope;
+        renderUpsert();
+        upsertInput.focus();
+    });
+});
+
+/* ---------- printing ---------- */
+
+window.addEventListener('beforeprint', () => {
+    if (!state.printSelection.size) {
+        document.body.classList.add('print-all');
+    } else {
+        for (const p of deskEl.querySelectorAll('.paper')) {
+            p.classList.toggle('print-selected',
+                state.printSelection.has(Number(p.dataset.listId)));
+        }
+    }
+});
+
+window.addEventListener('afterprint', () => {
+    document.body.classList.remove('print-all');
+    for (const p of deskEl.querySelectorAll('.print-selected')) {
+        p.classList.remove('print-selected');
+    }
+});
+
+/* ---------- toolbar & init ---------- */
+
+document.getElementById('new-paper-btn').addEventListener('click', newPaper);
+document.getElementById('drawer-btn').addEventListener('click', toggleDrawer);
+document.getElementById('print-btn').addEventListener('click', () => window.print());
+document.getElementById('refresh-btn').addEventListener('click', () => guard(reload));
+
+window.addEventListener('focus', () => {
+    if (Date.now() - lastLoad > 5000 && !document.querySelector('.inline-form')) {
+        guard(reload);
+    }
+});
+
+guard(reload);

--- a/desk/app.js
+++ b/desk/app.js
@@ -20,6 +20,7 @@ const state = {
     picked: null,              // card_id picked up for keyboard moves
     printSelection: new Set(), // list_ids marked for printing
     lastCategory: DEFAULT_CATEGORY,
+    filterCategory: null,      // only show this category_id; null = all (ephemeral)
     drawerOpen: false,
 };
 
@@ -32,6 +33,7 @@ const drawerEmptyEl = document.getElementById('drawer-empty');
 const upsertInput = document.getElementById('upsert-input');
 const upsertScopeBtn = document.getElementById('upsert-scope');
 const upsertResultsEl = document.getElementById('upsert-results');
+const catFilterEl = document.getElementById('category-filter');
 const awayDialog = document.getElementById('away-dialog');
 const awayNameEl = document.getElementById('away-name');
 const awayDateEl = document.getElementById('away-date');
@@ -61,6 +63,12 @@ function deskPapers() {
         (a, b) => paperSortKey(a) - paperSortKey(b) || a.list_id - b.list_id);
 }
 
+function visibleCards(list) {
+    return state.filterCategory === null
+        ? list.cards
+        : list.cards.filter((c) => c.category_id === state.filterCategory);
+}
+
 function currentPaper() {
     return state.papers.get(state.focus.listId) || deskPapers()[0] || null;
 }
@@ -85,6 +93,7 @@ async function reload() {
     const [cats, onDesk, away] = await Promise.all(
         [api.getCategories(), api.getLists(false), api.getLists(true)]);
     state.categories = new Map(cats.map((c) => [c.category_id, c]));
+    renderFilterOptions();
     const full = await Promise.all(onDesk.map((l) => api.getList(l.list_id)));
     state.papers = new Map(full.map((l) => [l.list_id, l]));
     state.drawer = away;
@@ -220,7 +229,7 @@ function paperEl(list, q) {
     const ul = document.createElement('ul');
     ul.className = 'cards';
     let anyMatch = false;
-    for (const card of list.cards) {
+    for (const card of visibleCards(list)) {
         const li = cardEl(card, list, q);
         if (q && li.classList.contains('match')) anyMatch = true;
         ul.append(li);
@@ -394,7 +403,7 @@ function newCard(list) {
     const li = document.createElement('li');
     li.append(inlineForm({
         withCategory: true,
-        categoryId: state.lastCategory,
+        categoryId: state.filterCategory ?? state.lastCategory,
         onCommit: (v) => guard(async () => {
             state.lastCategory = v.categoryId;
             const created = await api.createCard(list.list_id,
@@ -623,7 +632,7 @@ function navigate(key) {
     const papers = deskPapers();
     if (!papers.length) return;
     const list = currentPaper();
-    const cards = list.cards;
+    const cards = visibleCards(list);
     const idx = cards.findIndex((c) => c.card_id === state.focus.cardId);
     if (key === 's') {
         if (idx < cards.length - 1) {
@@ -639,9 +648,10 @@ function navigate(key) {
         const pi = papers.indexOf(list);
         const target = papers[pi + (key === 'd' ? 1 : -1)];
         if (!target) return;
+        const targetCards = visibleCards(target);
         state.focus = {
             listId: target.list_id,
-            cardId: target.cards.length ? target.cards[0].card_id : null,
+            cardId: targetCards.length ? targetCards[0].card_id : null,
         };
     }
     restoreFocus();
@@ -650,7 +660,7 @@ function navigate(key) {
 function movePicked(key) {
     const list = state.papers.get(state.focus.listId);
     if (!list) return;
-    const cards = list.cards;
+    const cards = visibleCards(list);
     const idx = cards.findIndex((c) => c.card_id === state.picked);
     if (idx < 0) return;
     let payload = null;
@@ -692,6 +702,52 @@ function toggleDrawer() {
     renderDrawer();
 }
 
+/* ---------- category filter (ephemeral; null = show all) ---------- */
+
+function renderFilterOptions() {
+    if (state.filterCategory !== null && !state.categories.has(state.filterCategory)) {
+        state.filterCategory = null;
+    }
+    catFilterEl.textContent = '';
+    const all = document.createElement('option');
+    all.value = '';
+    all.textContent = 'All categories';
+    catFilterEl.append(all);
+    for (const cat of state.categories.values()) {
+        const opt = document.createElement('option');
+        opt.value = cat.category_id;
+        opt.textContent = cat.category_name;
+        catFilterEl.append(opt);
+    }
+    catFilterEl.value = state.filterCategory === null ? '' : String(state.filterCategory);
+    catFilterEl.classList.toggle('filtering', state.filterCategory !== null);
+}
+
+function cardHidden(cardId) {
+    if (cardId === null || state.filterCategory === null) return false;
+    for (const l of state.papers.values()) {
+        const c = l.cards.find((x) => x.card_id === cardId);
+        if (c) return c.category_id !== state.filterCategory;
+    }
+    return false;
+}
+
+function setFilter(catId) {
+    state.filterCategory = catId;
+    catFilterEl.value = catId === null ? '' : String(catId);
+    catFilterEl.classList.toggle('filtering', catId !== null);
+    if (cardHidden(state.focus.cardId)) state.focus.cardId = null;
+    if (cardHidden(state.picked)) state.picked = null;
+    render();
+}
+
+function cycleFilter() {
+    const ids = [...state.categories.keys()];
+    if (!ids.length) return;
+    const i = ids.indexOf(state.filterCategory); // -1 when showing all
+    setFilter(i === ids.length - 1 ? null : ids[i + 1]);
+}
+
 document.addEventListener('keydown', (e) => {
     if (e.ctrlKey || e.metaKey || e.altKey || e.defaultPrevented) return;
     if (e.target.closest('input, textarea, select')) return;
@@ -714,6 +770,7 @@ document.addEventListener('keydown', (e) => {
         case 'r': if (list) renamePaper(list); break;
         case 'z': if (list) putAwayDialog(list); break;
         case 'b': toggleDrawer(); break;
+        case 'f': cycleFilter(); break;
         case '/': case 'u': upsertInput.focus(); upsertInput.select(); break;
         case 'p': if (list) togglePrintSelection(list); break;
         case 'P': window.print(); break;
@@ -721,6 +778,7 @@ document.addEventListener('keydown', (e) => {
         case 'Escape':
             if (state.picked !== null) { state.picked = null; render(); }
             else if (upsert.query) clearUpsert();
+            else if (state.filterCategory !== null) setFilter(null);
             else if (state.drawerOpen) toggleDrawer();
             break;
         default: return;
@@ -748,13 +806,13 @@ function upsertMatches() {
     const out = [];
     if (!q) return out;
     for (const l of deskPapers()) {
-        for (const c of l.cards) {
+        for (const c of visibleCards(l)) {
             if (c.card_name.toLowerCase().includes(q)) out.push({ card: c, list: l, away: false });
         }
     }
     if (upsert.scope === 'all') {
         for (const l of state.drawerCards.values()) {
-            for (const c of l.cards) {
+            for (const c of visibleCards(l)) {
                 if (c.card_name.toLowerCase().includes(q)) out.push({ card: c, list: l, away: true });
             }
         }
@@ -818,7 +876,7 @@ function createFromUpsert() {
     if (!target || !cardName) return;
     guard(async () => {
         const created = await api.createCard(target.list_id,
-            { card_name: cardName, category_id: state.lastCategory });
+            { card_name: cardName, category_id: state.filterCategory ?? state.lastCategory });
         state.focus = { listId: target.list_id, cardId: created.card_id };
         await refreshPapers([target.list_id]);
         clearUpsert();
@@ -902,6 +960,8 @@ document.getElementById('new-paper-btn').addEventListener('click', newPaper);
 document.getElementById('drawer-btn').addEventListener('click', toggleDrawer);
 document.getElementById('print-btn').addEventListener('click', () => window.print());
 document.getElementById('refresh-btn').addEventListener('click', () => guard(reload));
+catFilterEl.addEventListener('change', () =>
+    setFilter(catFilterEl.value ? Number(catFilterEl.value) : null));
 
 window.addEventListener('focus', () => {
     if (Date.now() - lastLoad > 5000 && !document.querySelector('.inline-form')) {

--- a/desk/desk.css
+++ b/desk/desk.css
@@ -98,6 +98,7 @@ kbd {
 #upsert-box {
     display: flex;
     align-items: stretch;
+    position: relative;
 }
 
 #upsert-input {
@@ -139,8 +140,8 @@ kbd {
 #upsert-results {
     position: absolute;
     z-index: 40;
-    top: 2.6rem;
-    left: 8.5rem;
+    top: calc(100% + 2px);
+    left: 0;
     max-width: 26rem;
     margin: 0;
     padding: 0.25rem;
@@ -224,7 +225,7 @@ kbd {
     padding: 0.55rem 0.6rem 0.15rem;
     border-bottom: 2px solid var(--ink);
     cursor: grab;
-    touch-action: none; /* let pointer-event drags work on touch */
+    touch-action: pan-y; /* vertical touch scrolls; horizontal touch drags the paper */
 }
 
 .paper header h2 {
@@ -284,7 +285,7 @@ kbd {
     border-left: 4px solid var(--cat-color);
     font: 0.82rem/1.25 var(--mono);
     cursor: default;
-    touch-action: none; /* let pointer-event drags work on touch */
+    touch-action: pan-y; /* vertical touch scrolls; horizontal touch drags the card */
 }
 
 .card .name {
@@ -504,6 +505,47 @@ kbd {
 
 @media (prefers-reduced-motion: reduce) {
     * { transition: none !important; }
+}
+
+/* ---------- touch: no hover, fat fingers ---------- */
+
+@media (hover: none) {
+    :root { --rule-height: 34px; }
+
+    .paper header .tools { opacity: 1; }
+
+    .paper header .tools button,
+    .card button {
+        font-size: 1rem;
+        padding: 6px;
+    }
+}
+
+/* ---------- small screens: one paper at a time ---------- */
+
+@media (max-width: 600px) {
+    #desk {
+        gap: 1rem;
+        padding: 1rem;
+        scroll-snap-type: x proximity;
+    }
+
+    .paper {
+        flex-basis: 88vw;
+        width: 88vw;
+        scroll-snap-align: center;
+    }
+
+    #upsert-box { flex: 1 1 100%; }
+
+    #upsert-input {
+        width: auto;
+        flex: 1;
+        max-width: none;
+    }
+
+    #toolbar kbd,
+    #help { display: none; }
 }
 
 /* ---------- print: selected papers as clean sheets ---------- */

--- a/desk/desk.css
+++ b/desk/desk.css
@@ -1,0 +1,543 @@
+/* TaskMaster Desk — papers on a desk.
+   Palette: blotter-green desk, warm ruled paper, brass accents, warm-black tray. */
+
+:root {
+    --desk: #3A5244;
+    --desk-edge: #2C4034;
+    --paper: #FBF7EB;
+    --paper-edge: #E6DEC6;
+    --rule: rgba(96, 138, 184, 0.30);
+    --rule-height: 28px;
+    --ink: #2B2620;
+    --ink-soft: #7A7060;
+    --brass: #B98A2F;
+    --chrome: #23201A;
+    --chrome-ink: #E9E1CF;
+    --focus: #2F6FD6;
+    --cat-color: #9A938A;
+    --serif: Georgia, 'Iowan Old Style', 'Times New Roman', serif;
+    --mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    --sans: system-ui, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+    margin: 0;
+    height: 100%;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+    font-family: var(--sans);
+    color: var(--ink);
+    background:
+        radial-gradient(ellipse at 50% -20%, var(--desk) 60%, var(--desk-edge) 100%);
+}
+
+kbd {
+    font-family: var(--mono);
+    font-size: 0.72em;
+    padding: 1px 4px;
+    border: 1px solid currentColor;
+    border-radius: 3px;
+    opacity: 0.65;
+}
+
+:focus-visible {
+    outline: 2px solid var(--focus);
+    outline-offset: 1px;
+}
+
+/* ---------- toolbar tray ---------- */
+
+#toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.45rem 0.9rem;
+    background: var(--chrome);
+    color: var(--chrome-ink);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+    flex-wrap: wrap;
+}
+
+#brand {
+    font-family: var(--serif);
+    font-size: 1.05rem;
+    letter-spacing: 0.02em;
+    margin-right: 0.4rem;
+    white-space: nowrap;
+}
+
+#brand em {
+    color: var(--brass);
+    font-style: italic;
+}
+
+#toolbar .spacer { flex: 1; }
+
+#toolbar button {
+    font: 600 0.72rem var(--sans);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--chrome-ink);
+    background: transparent;
+    border: 1px solid rgba(233, 225, 207, 0.35);
+    border-radius: 4px;
+    padding: 0.3rem 0.55rem;
+    cursor: pointer;
+}
+
+#toolbar button:hover {
+    border-color: var(--brass);
+    color: #fff;
+}
+
+#upsert-box {
+    display: flex;
+    align-items: stretch;
+}
+
+#upsert-input {
+    font: 0.85rem var(--mono);
+    width: 16rem;
+    max-width: 40vw;
+    padding: 0.28rem 0.5rem;
+    color: var(--chrome-ink);
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(233, 225, 207, 0.35);
+    border-right: none;
+    border-radius: 4px 0 0 4px;
+}
+
+#upsert-input::placeholder { color: rgba(233, 225, 207, 0.5); }
+
+#upsert-box button { border-radius: 0 4px 4px 0; }
+
+/* ---------- upsert results ---------- */
+
+#upsert-results {
+    position: absolute;
+    z-index: 40;
+    top: 2.6rem;
+    left: 8.5rem;
+    max-width: 26rem;
+    margin: 0;
+    padding: 0.25rem;
+    list-style: none;
+    background: var(--paper);
+    border: 1px solid var(--paper-edge);
+    border-radius: 4px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+    font-family: var(--mono);
+    font-size: 0.85rem;
+}
+
+#upsert-results li {
+    padding: 0.3rem 0.5rem;
+    border-radius: 3px;
+    cursor: pointer;
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+}
+
+#upsert-results li.selected { background: rgba(185, 138, 47, 0.25); }
+
+#upsert-results li .where {
+    font-family: var(--sans);
+    font-size: 0.7rem;
+    color: var(--ink-soft);
+    white-space: nowrap;
+}
+
+#upsert-results li.create { font-style: italic; color: var(--ink-soft); }
+
+/* ---------- desk row ---------- */
+
+#desk {
+    flex: 1;
+    display: flex;
+    align-items: flex-start;
+    gap: 1.6rem;
+    padding: 1.6rem 1.8rem 2.2rem;
+    overflow-x: auto;
+    overflow-y: auto;
+}
+
+/* ---------- papers ---------- */
+
+.paper {
+    flex: 0 0 260px;
+    width: 260px;
+    min-height: calc(var(--rule-height) * 8);
+    background: var(--paper);
+    border: 1px solid var(--paper-edge);
+    border-radius: 1px;
+    box-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.25),
+        0 8px 18px rgba(0, 0, 0, 0.30);
+    transform: rotate(var(--tilt, 0deg));
+    display: flex;
+    flex-direction: column;
+    transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.paper.drag {
+    transform: rotate(0deg) scale(1.03);
+    box-shadow: 0 18px 34px rgba(0, 0, 0, 0.5);
+    opacity: 0.92;
+    z-index: 10;
+    cursor: grabbing;
+}
+
+.paper.woken {
+    box-shadow:
+        0 0 0 3px var(--brass),
+        0 8px 18px rgba(0, 0, 0, 0.30);
+}
+
+.paper header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    padding: 0.55rem 0.6rem 0.15rem;
+    border-bottom: 2px solid var(--ink);
+    cursor: grab;
+    touch-action: none; /* let pointer-event drags work on touch */
+}
+
+.paper header h2 {
+    flex: 1;
+    margin: 0;
+    font: 600 1.02rem var(--serif);
+    letter-spacing: 0.01em;
+    overflow-wrap: anywhere;
+}
+
+.paper header .tools {
+    display: flex;
+    gap: 0.15rem;
+    align-items: center;
+    opacity: 0.35;
+    transition: opacity 100ms;
+}
+
+.paper:hover header .tools,
+.paper:focus-within header .tools { opacity: 1; }
+
+.paper header .tools button,
+.card button {
+    font-size: 0.8rem;
+    line-height: 1;
+    background: none;
+    border: none;
+    padding: 2px 3px;
+    cursor: pointer;
+    color: var(--ink-soft);
+    border-radius: 3px;
+}
+
+.paper header .tools button:hover,
+.card button:hover { color: var(--ink); background: rgba(0, 0, 0, 0.07); }
+
+.paper header .tools input[type="checkbox"] {
+    accent-color: var(--brass);
+    margin: 0 1px;
+}
+
+.paper .cards {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+/* ---------- cards: typed lines on ruled paper ---------- */
+
+.card {
+    display: flex;
+    align-items: baseline;
+    gap: 0.3rem;
+    min-height: var(--rule-height);
+    padding: 5px 0.35rem 0 0.5rem;
+    border-bottom: 1px solid var(--rule);
+    border-left: 4px solid var(--cat-color);
+    font: 0.82rem/1.25 var(--mono);
+    cursor: default;
+    touch-action: none; /* let pointer-event drags work on touch */
+}
+
+.card .name {
+    flex: 1;
+    overflow-wrap: anywhere;
+}
+
+.card .due {
+    font-size: 0.68rem;
+    color: var(--ink-soft);
+    white-space: nowrap;
+}
+
+.card:focus-visible {
+    outline: none;
+    background: rgba(47, 111, 214, 0.10);
+    border-left-width: 8px;
+}
+
+.card.picked {
+    background: rgba(185, 138, 47, 0.22);
+    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.25);
+}
+
+.card.drop-slot {
+    background: rgba(47, 111, 214, 0.12);
+    border: 1px dashed var(--focus);
+    border-left: 4px dashed var(--focus);
+}
+
+.card.drop-slot > * { visibility: hidden; }
+
+.card.match { background: rgba(185, 138, 47, 0.28); }
+
+.dimmed { opacity: 0.35; }
+
+#drag-clone {
+    position: fixed;
+    z-index: 100;
+    pointer-events: none;
+    width: 240px;
+    background: var(--paper);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.5);
+    transform: rotate(-1.5deg);
+    list-style: none;
+}
+
+/* blank ruled lines at the bottom of each sheet = add-a-task zone */
+
+.paper .blank-lines {
+    flex: 1;
+    min-height: calc(var(--rule-height) * 3);
+    background: repeating-linear-gradient(
+        to bottom,
+        transparent 0,
+        transparent calc(var(--rule-height) - 1px),
+        var(--rule) calc(var(--rule-height) - 1px),
+        var(--rule) var(--rule-height));
+    cursor: text;
+    border-radius: 0 0 1px 1px;
+}
+
+.paper .blank-lines:hover { background-color: rgba(0, 0, 0, 0.02); }
+
+/* inline editing */
+
+.inline-form {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+    padding: 2px 0.35rem;
+}
+
+.inline-form input[type="text"] {
+    flex: 1;
+    min-width: 3rem;
+    font: 0.82rem var(--mono);
+    padding: 2px 4px;
+    border: 1px solid var(--brass);
+    border-radius: 2px;
+    background: #fff;
+    color: var(--ink);
+}
+
+.inline-form input[type="date"],
+.inline-form select {
+    font: 0.7rem var(--sans);
+    max-width: 7.5rem;
+    border: 1px solid var(--paper-edge);
+    border-radius: 2px;
+    background: #fff;
+    color: var(--ink);
+}
+
+.paper header .inline-form input[type="text"] { font-family: var(--serif); }
+
+/* ---------- drawer ---------- */
+
+#drawer {
+    background: linear-gradient(#4E3A26, #3E2E1E);
+    color: #EFE6D2;
+    padding: 0.6rem 1.2rem 1rem;
+    box-shadow: 0 -6px 18px rgba(0, 0, 0, 0.5);
+    border-top: 3px solid #63492F;
+}
+
+#drawer h2 {
+    margin: 0 0 0.5rem;
+    font: 600 0.75rem var(--sans);
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--brass);
+}
+
+/* drawer handle */
+#drawer h2::before {
+    content: '';
+    display: block;
+    width: 4rem;
+    height: 5px;
+    margin: 0 auto 0.5rem;
+    border-radius: 3px;
+    background: var(--brass);
+    opacity: 0.8;
+}
+
+#drawer-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+#drawer-tabs li {
+    background: var(--paper);
+    color: var(--ink);
+    font: 0.8rem var(--serif);
+    padding: 0.35rem 0.7rem 0.25rem;
+    border-radius: 1px 6px 1px 1px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.4);
+    cursor: pointer;
+    transform: rotate(-0.5deg);
+}
+
+#drawer-tabs li:nth-child(even) { transform: rotate(0.6deg); }
+
+#drawer-tabs li:hover { transform: translateY(-3px); }
+
+#drawer-tabs li .wake {
+    display: block;
+    font: 0.65rem var(--sans);
+    color: var(--ink-soft);
+}
+
+#drawer-empty { font-size: 0.8rem; opacity: 0.7; }
+
+/* ---------- help footer ---------- */
+
+#help {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding: 0.3rem 1rem;
+    font-size: 0.68rem;
+    color: rgba(233, 225, 207, 0.75);
+    background: rgba(0, 0, 0, 0.25);
+}
+
+#help span { white-space: nowrap; }
+
+/* ---------- put-away dialog ---------- */
+
+#away-dialog {
+    border: 1px solid var(--paper-edge);
+    border-radius: 4px;
+    background: var(--paper);
+    color: var(--ink);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+    font-family: var(--sans);
+}
+
+#away-dialog::backdrop { background: rgba(20, 30, 24, 0.55); }
+
+#away-dialog h3 { margin-top: 0; font-family: var(--serif); }
+
+#away-dialog label {
+    display: block;
+    font-size: 0.8rem;
+    margin-bottom: 0.3rem;
+    color: var(--ink-soft);
+}
+
+#away-dialog menu {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    padding: 0;
+    margin: 1rem 0 0;
+}
+
+#away-dialog button {
+    font: 600 0.75rem var(--sans);
+    padding: 0.35rem 0.8rem;
+    border-radius: 4px;
+    border: 1px solid var(--paper-edge);
+    background: #fff;
+    cursor: pointer;
+}
+
+#away-dialog #away-ok {
+    background: var(--brass);
+    border-color: var(--brass);
+    color: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    * { transition: none !important; }
+}
+
+/* ---------- print: selected papers as clean sheets ---------- */
+
+@media print {
+    body { background: #fff; display: block; }
+
+    #toolbar, #drawer, #help, #upsert-results,
+    .paper .tools, .card button, .blank-lines { display: none !important; }
+
+    #desk {
+        display: block;
+        overflow: visible;
+        padding: 0;
+    }
+
+    .paper {
+        display: none;
+        width: 100%;
+        min-height: 0;
+        border: none;
+        box-shadow: none;
+        transform: none;
+        break-inside: avoid;
+        margin-bottom: 1.5rem;
+    }
+
+    body.print-all .paper,
+    .paper.print-selected { display: block; }
+
+    .paper header {
+        cursor: default;
+        border-bottom: 2px solid #000;
+        padding-left: 0;
+    }
+
+    .card {
+        border-left: none;
+        border-bottom: 1px solid #ccc;
+        color: #000;
+        padding-left: 0;
+    }
+
+    .card .name::before { content: '\2610\00a0\00a0'; }
+
+    .card .cat {
+        font-size: 0.65rem;
+        color: #555;
+        white-space: nowrap;
+    }
+}
+
+@media not print {
+    .card .cat { display: none; }
+}

--- a/desk/desk.css
+++ b/desk/desk.css
@@ -116,6 +116,24 @@ kbd {
 
 #upsert-box button { border-radius: 0 4px 4px 0; }
 
+#category-filter {
+    font: 600 0.72rem var(--sans);
+    letter-spacing: 0.06em;
+    color: var(--chrome-ink);
+    background: var(--chrome);
+    border: 1px solid rgba(233, 225, 207, 0.35);
+    border-radius: 4px;
+    padding: 0.3rem 0.4rem;
+    cursor: pointer;
+}
+
+#category-filter:hover { border-color: var(--brass); color: #fff; }
+
+#category-filter.filtering {
+    border-color: var(--brass);
+    color: #fff;
+}
+
 /* ---------- upsert results ---------- */
 
 #upsert-results {

--- a/desk/index.html
+++ b/desk/index.html
@@ -13,6 +13,7 @@
   <span id="upsert-box">
     <input id="upsert-input" type="search" placeholder="Find or add a task (/)" autocomplete="off">
     <button id="upsert-scope" title="Toggle search scope">visible</button>
+    <ul id="upsert-results" hidden></ul>
   </span>
   <select id="category-filter" title="Filter by category (f cycles)">
     <option value="">All categories</option>
@@ -23,7 +24,6 @@
   <button id="print-btn">Print <kbd>P</kbd></button>
   <button id="refresh-btn" title="Refresh from server">&#10227; <kbd>g</kbd></button>
 </header>
-<ul id="upsert-results" hidden></ul>
 <main id="desk"></main>
 <aside id="drawer" hidden>
   <h2>Drawer</h2>

--- a/desk/index.html
+++ b/desk/index.html
@@ -14,6 +14,9 @@
     <input id="upsert-input" type="search" placeholder="Find or add a task (/)" autocomplete="off">
     <button id="upsert-scope" title="Toggle search scope">visible</button>
   </span>
+  <select id="category-filter" title="Filter by category (f cycles)">
+    <option value="">All categories</option>
+  </select>
   <span class="spacer"></span>
   <button id="new-paper-btn">New paper <kbd>N</kbd></button>
   <button id="drawer-btn">Drawer <kbd>b</kbd></button>
@@ -39,6 +42,7 @@
   <span><kbd>r</kbd> rename</span>
   <span><kbd>z</kbd> put away</span>
   <span><kbd>p</kbd> mark for print</span>
+  <span><kbd>f</kbd> filter category</span>
 </footer>
 <dialog id="away-dialog">
   <form method="dialog">

--- a/desk/index.html
+++ b/desk/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TaskMaster Desk</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14' font-size='14'>&#128221;</text></svg>">
+<link rel="stylesheet" href="desk.css">
+</head>
+<body>
+<header id="toolbar">
+  <span id="brand">TaskMaster <em>desk</em></span>
+  <span id="upsert-box">
+    <input id="upsert-input" type="search" placeholder="Find or add a task (/)" autocomplete="off">
+    <button id="upsert-scope" title="Toggle search scope">visible</button>
+  </span>
+  <span class="spacer"></span>
+  <button id="new-paper-btn">New paper <kbd>N</kbd></button>
+  <button id="drawer-btn">Drawer <kbd>b</kbd></button>
+  <button id="print-btn">Print <kbd>P</kbd></button>
+  <button id="refresh-btn" title="Refresh from server">&#10227; <kbd>g</kbd></button>
+</header>
+<ul id="upsert-results" hidden></ul>
+<main id="desk"></main>
+<aside id="drawer" hidden>
+  <h2>Drawer</h2>
+  <ul id="drawer-tabs"></ul>
+  <p id="drawer-empty" hidden>Nothing put away.</p>
+</aside>
+<footer id="help">
+  <span><kbd>w</kbd><kbd>s</kbd> card</span>
+  <span><kbd>a</kbd><kbd>d</kbd> paper</span>
+  <span><kbd>m</kbd> pick up / drop</span>
+  <span><kbd>n</kbd> new task</span>
+  <span><kbd>e</kbd> edit</span>
+  <span><kbd>c</kbd> done</span>
+  <span><kbd>N</kbd> new paper</span>
+  <span><kbd>A</kbd><kbd>D</kbd> move paper</span>
+  <span><kbd>r</kbd> rename</span>
+  <span><kbd>z</kbd> put away</span>
+  <span><kbd>p</kbd> mark for print</span>
+</footer>
+<dialog id="away-dialog">
+  <form method="dialog">
+    <h3>Put away &ldquo;<span id="away-name"></span>&rdquo;</h3>
+    <label for="away-date">Wake up on (optional)</label>
+    <input type="date" id="away-date">
+    <menu>
+      <button value="cancel" type="submit">Cancel</button>
+      <button value="ok" type="submit" id="away-ok">Put away</button>
+    </menu>
+  </form>
+</dialog>
+<script type="module" src="app.js"></script>
+</body>
+</html>

--- a/kanapi.py
+++ b/kanapi.py
@@ -1,8 +1,11 @@
 """KanBan API and DataBase"""
 
 import datetime
+import pathlib
 from typing import Optional
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from sqlmodel import Field, SQLModel, Session, create_engine, Relationship, select
 
 SQLITE_FILE = 'kanban.test.db'
@@ -60,6 +63,17 @@ class CardPatch(SQLModel):
     card_pom_tgt: Optional[int] = None
 
 
+class ListPatch(SQLModel):
+    """List Patch
+
+    board_order doubles as desk placement: an explicit null puts the list
+    "away" (off the desk), same idiom as closed cards getting a null list_order
+    """
+    list_name: str | None = None
+    board_order: Optional[int] = None
+    list_wakeup: Optional[datetime.date] = None
+
+
 class Card(CardBase, table=True):
     """An index card or task"""
     card_id: int = Field(primary_key = True)
@@ -108,6 +122,14 @@ def create_db_and_tables():
 
 app = FastAPI(
         title="TaskMaster KanBan API"
+        )
+
+# NOTE revisit allow_origins if auth is ever added
+app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
         )
 
 def get_session():
@@ -159,6 +181,23 @@ def card_list_order(card: Card) -> int:
     if not card.list_order:
         return 0
     return card.list_order
+
+def list_on_desk(list_: List) -> bool:
+    """Whether a list is "on the desk" (i.e. not put away)
+
+    A wakeup date governs if set; otherwise presence of board_order decides.
+    A NULL board_order means the list has been put away, but a wakeup date
+    that has arrived brings it back regardless.
+    """
+    if list_.list_wakeup:
+        return list_.list_wakeup <= datetime.date.today()
+    return list_.board_order is not None
+
+def list_board_order(list_: List) -> int:
+    """Given a list, return the board order; safe for sorting (nulls last)"""
+    if list_.board_order is None:
+        return MAX_ORDER + 1
+    return list_.board_order
 
 
 @app.get("/lists/{list_id}", response_model=ListWithCards)
@@ -277,10 +316,44 @@ def one_card(*, session: Session = Depends(get_session), card_id: int):
     return card
 
 @app.get("/lists/", response_model=list[List])
-def get_lists(*, session: Session = Depends(get_session)):
-    """Get all lists"""
+def get_lists(*, session: Session = Depends(get_session), away: Optional[bool] = None):
+    """Get all lists, optionally filtered by whether they are put away"""
     lists = session.exec(select(List)).all()
-    return lists
+    if away is not None:
+        lists = [x for x in lists if list_on_desk(x) != away]
+    return sorted(lists, key=list_board_order)
+
+@app.patch("/lists/{list_id}", response_model=List)
+def patch_list(*, session: Session = Depends(get_session), list_id: int, list_patch: ListPatch):
+    """Update certian fields in a list
+
+    Rename, reorder on the desk, put away (board_order=null), or set wakeup
+    """
+    list_ = session.get(List, list_id)
+    if not list_:
+        raise HTTPException(status_code=404)
+    list_data = list_patch.model_dump(exclude_unset=True)
+    list_.sqlmodel_update(list_data)
+    session.commit()
+    session.refresh(list_)
+    return list_
+
+@app.post("/lists/{list_id}/rebalance", response_model=ListMoveResult)
+def rebalance_list(*, session: Session = Depends(get_session), list_id: int):
+    """Evenly re-space the list_order of all cards on a list
+
+    Midpoint insertion in generate_list_order can exhaust the gap between two
+    adjacent cards; this spreads all cards back out over the full range.
+    """
+    list_ = session.get(List, list_id)
+    if not list_:
+        raise HTTPException(status_code=404)
+    cards = sorted(list_.cards, key=card_list_order)
+    step = (MAX_ORDER - MIN_ORDER) // (len(cards) + 1)
+    for index, card in enumerate(cards, start=1):
+        card.list_order = MIN_ORDER + index * step
+    session.commit()
+    return ListMoveResult()
 
 @app.get("/categories/", response_model=list[Category])
 def get_categories(*, session: Session = Depends(get_session)):
@@ -305,3 +378,8 @@ def move_list(*, session: Session = Depends(get_session), list_id: int, directio
         card.list_id = end_list.list_id
     session.commit()
     return ListMoveResult()  # TODO boring...
+
+# "Papers on a desk" web frontend; mounted after all API routes
+app.mount("/desk",
+          StaticFiles(directory=pathlib.Path(__file__).parent / "desk", html=True),
+          name="desk")


### PR DESCRIPTION
## Summary

Replaces the strict KanBan-columns paradigm with a **"papers on a desk"** web frontend: each list is a paper laid side by side in a row on a desk, quick to create, reorder, rename, and **put away into a drawer** (optionally with a wakeup date so it comes back automatically). Served by kanapi itself at `/desk/` — vanilla JS/CSS/HTML, no build step, no new dependencies.

## Frontend (`desk/`)

- Papers rendered as tilted ruled sheets; tasks are typed lines with their **category color** as a margin stripe (first client to read `category_color` from the DB; stable fallback palette when unset)
- **Mouse**: drag papers to reorder the row, drag tasks within/between papers, click the blank ruled lines to add a task
- **Keyboard**: TUI-compatible keys (`n`/`e`/`m`/`wasd`/`c`) plus `N` new paper, `A`/`D` move paper, `r` rename, `z` put away, `b` drawer, `p`/`P` print, `g` refresh
- **Upsert search** (`/`): live-filters tasks on visible (or all) papers; Enter jumps to a match, or writes the task on the current paper when nothing matches
- **Printing**: one paper, marked papers, or the whole desk as clean black-on-white checklists via `@media print`

## API (`kanapi.py`) — no DB schema change

- `board_order` is reused for desk position; **null `board_order` = put away**, mirroring closed cards' null `list_order`
- New: `PATCH /lists/{list_id}` (rename/reorder/put away/wakeup), `GET /lists/?away=<bool>` with the wakeup-aware on-desk rule, `POST /lists/{list_id}/rebalance` (re-spaces card orders when midpoint insertion exhausts a gap), CORS middleware, static mount for `desk/`
- Implements the roadmap item *server side board definition*; future TUI/Android clients can consume the same additions

## Notes

- Existing lists have no `board_order`, so on first run they start in the drawer — pull the ones you want onto the desk once (README updated)
- Closing a task still requires one `--closed` list to exist

## Test plan

- [x] curl smoke tests: PATCH rename/reorder/put-away, `?away=` filtering incl. wakeup edge cases, rebalance spacing, 404s
- [x] selenium + headless Firefox end-to-end: 13/13 interaction tests (create/edit/close, keyboard pick-and-move, upsert find + create-on-miss, put away, drawer pull-out, print selection) plus card/paper drag-and-drop with order persisting across reloads and print-to-PDF rendering
- [x] Regression: `kancli`/`kantui` unaffected (`GET /lists/` without `away` unchanged aside from stable ordering); pylint 9.55/10 with only pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)